### PR TITLE
Add vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/index.html"
+		}
+	]
+}


### PR DESCRIPTION
# 🚌 Add vercel.json for navigate to /resultados
Al momento de realizar la navegación a resultados, tira un error `404- Not Found`, para solucionar ello y nos detecte la ruta se configura un `vecel.json` con los siguientes parámetros:

```json
{
  "rewrites": [
    {
      "source": "/(.*)",
      "destination": "/index.html"
    }
  ]
}

```

## ❌ 404 - Not Found

https://github.com/YeyoM/wellness-landing/assets/78810527/5c86cb59-c83a-4ea5-ba27-df7fafbcc858

